### PR TITLE
Add usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # About this Repo
 
 This is the Git repo of the Docker image for groonga.
+
+## Usage
+
+```bash
+$ docker run -it groonga/groonga
+```


### PR DESCRIPTION
This Groonga Docker container provides "groonga" entrypoint.
Users can use Groonga via `docker run -it groonga/groonga` command.

Should we add more usage which needs to build container like as listening on HTTP on users' environment?