### PR TITLE
Include groonga-httpd executables in Groonga Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN curl -Lo groonga.tar.gz \
   http://packages.groonga.org/source/groonga/groonga-$VERSION.tar.gz && \
   tar xzf groonga.tar.gz && cd groonga-$VERSION && \
   ./configure --prefix=/usr \
-    --disable-maintainer-mode --disable-dependency-tracking \
-    --disable-groonga-httpd && \
+    --disable-maintainer-mode --disable-dependency-tracking && \
   make && make install && make clean && cd .. && rm -rf groonga*
 
 ENTRYPOINT ["groonga"]


### PR DESCRIPTION
We'are planning to write how to use Docker image.
And I've hit an issue about Groonga process which has no database path.
I want to install groonga-httpd executables and use as entrypoint like this approach:
https://github.com/hnakamur/groonga-dockerfiles/blob/master/dockerfiles/trusty/Dockerfile 