### PR TITLE
Shrink container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN curl -Lo groonga.tar.gz \
   ./configure --prefix=/usr \
     --disable-maintainer-mode --disable-dependency-tracking \
     --disable-groonga-httpd && \
-  make && make install && make clean && cd .. && rm -rf groonga*
+  make && make DESTDIR=/chroot install
 
+FROM alpine:3.8
+RUN apk --no-cache add jemalloc zeromq libevent msgpack-c
+COPY --from=0 /chroot/ /
 ENTRYPOINT ["groonga"]


### PR DESCRIPTION
remove build package from container(ex g++, make and dev packages).

| image name | image id | size |
|---------------|-----------|-----|
|groonga/groonga:latest | ```75afcbfe71f0``` | 221MB |
| new image | ```dbdf24d76ee7``` | 68.4MB |
