### PR TITLE
debian: remove apache-arrow-apt-source-latest.deb after installation

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     wget && \
   wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
-  rm ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+  rm ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   apt install -y -V ${quiet} ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -12,8 +12,6 @@ RUN \
     ca-certificates \
     lsb-release \
     wget && \
-  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
-  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   apt install -y -V ${quiet} ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -12,6 +12,9 @@ RUN \
     ca-certificates \
     lsb-release \
     wget && \
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   apt install -y -V ${quiet} ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \


### PR DESCRIPTION
GitHub: fix GH-6

Because keeping needless files increase image size.
