### PR TITLE
alpine: add a missing dependency library

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN \
     libarrow \
     libedit \
     libevent \
+    libgomp \
     libstemmer \
     lz4 \
     msgpack-c \


### PR DESCRIPTION
This modification fix the following error.

```console
$ docker run alpine-groonga-test-01
Error loading shared library libgomp.so.1: No such file or directory (needed by /usr/lib/libgroonga.so.0) Error relocating /usr/lib/libgroonga.so.0: GOMP_parallel: symbol not found Error relocating１１ /usr/lib/libgroonga.so.0: GOMP_single_start: symbol not found Error relocating /usr/lib/libgroonga.so.0: omp_get_num_threads: symbol not found Error relocating /usr/lib/libgroonga.so.0: GOMP_barrier: symbol not found Error relocating /usr/lib/libgroonga.so.0: omp_get_thread_num: symbol not found
```

llama.cpp uses OpenMP.
However, we had not installed libgomp in alpine docker image. So, we install libgomp in alpine docker image in this docker image in this modification.