### PR TITLE
release: Remove garbage "GROONGA_VERSION=" from release title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           dockerfile=${{ matrix.id }}/Dockerfile
           groonga_version=$(grep -o 'GROONGA_VERSION=[0-9.]*' ${dockerfile} | \
-                             cut -d: -f2 | \
+                             cut -d= -f2 | \
                              head -n1)
           echo "Groonga ${groonga_version}" | tee release-title.txt
           cat <<RELEASE_NOTE | tee release-note.md


### PR DESCRIPTION
https://github.com/groonga/docker/releases/tag/15.0.9 was "Groonga GROONGA_VERSION=15.0.9".