### PR TITLE
release: include Docker image tags and digests in GitHub Release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,10 @@ jobs:
       - name: Image info
         run: |
           cat <<IMAGE_INFO | tee release-image-info-${{ matrix.id }}.md
-          * Tags: ${TAGS}
+          ### ${TAGS}
+
           * Digest: \`${{ steps.docker_build.outputs.digest }}\`
+
           IMAGE_INFO
       - uses: actions/upload-artifact@v4
         with:
@@ -84,11 +86,11 @@ jobs:
       - name: Prepare release note
         run: |
           echo "Groonga ${GITHUB_REF_NAME}" | tee release-title.txt
-          echo "* Commit: https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_REF_NAME}" |
-            tee release-note.md
-          for image_info in release-image-info/*; do
-            cat $image_info | tee -a release-note.md
-          done
+          cat <<RELEASE_NOTE | tee release-note.md
+          Commit: https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_REF_NAME}
+
+          $(cat release-image-info/*)
+          RELEASE_NOTE
       - name: Create GitHub Release
         if: github.ref_type == 'tag'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,29 +59,42 @@ jobs:
           tags: ${{ env.TAGS }}
       - name: Image info
         run: |
-          dockerfile=${{ matrix.id }}/Dockerfile
-          groonga_version=$(grep -o 'GROONGA_VERSION=[0-9.]*' ${dockerfile} | \
-                             cut -d= -f2 | \
-                             head -n1)
-          echo "Groonga ${groonga_version}" | tee release-title.txt
-          cat <<RELEASE_NOTE | tee release-note.md
-          * Commit: https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_REF_NAME}
+          cat <<IMAGE_INFO | tee release-image-info-${{ matrix.id }}.md
           * Tags: ${TAGS}
           * Digest: \`${{ steps.docker_build.outputs.digest }}\`
-          RELEASE_NOTE
+          IMAGE_INFO
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-image-info-${{ matrix.id }}
+          path: release-image-info-${{ matrix.id }}.md
+      - name: Test if groonga command is executable
+        run: |
+          docker container run --rm --entrypoint "groonga" "${TAG}" --version
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-image-info
+          pattern: release-image-info-*
+          merge-multiple: true
+      - name: Prepare release note
+        run: |
+          echo "Groonga ${GITHUB_REF_NAME}" | tee release-title.txt
+          echo "* Commit: https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_REF_NAME}" |
+            tee release-note.md
+          for image_info in release-image-info/*; do
+            cat $image_info | tee -a release-note.md
+          done
       - name: Create GitHub Release
         if: github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            echo "Release page for ${GITHUB_REF_NAME} already exists."
-          else
-            gh release create "${GITHUB_REF_NAME}" \
-              --discussion-category Announcements \
-              --notes-file release-note.md \
-              --title "$(cat release-title.txt)"
-          fi
-      - name: Test if groonga command is executable
-        run: |
-          docker container run --rm --entrypoint "groonga" "${TAG}" --version
+          gh release create "${GITHUB_REF_NAME}" \
+            --discussion-category Announcements \
+            --notes-file release-note.md \
+            --title "$(cat release-title.txt)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --discussion-category Announcements \
-            --notes-file release-note.md \
-            --title "$(cat release-title.txt)"
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "Release page for ${GITHUB_REF_NAME} already exists."
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --discussion-category Announcements \
+              --notes-file release-note.md \
+              --title "$(cat release-title.txt)"
+          fi
       - name: Test if groonga command is executable
         run: |
           docker container run --rm --entrypoint "groonga" "${TAG}" --version


### PR DESCRIPTION
## Problem

When matrix jobs run in parallel, `gh release create` can be invoked multiple times for the same tag,
resulting in a “Release.tag_name already exists” error.

```
Run gh release create "${GITHUB_REF_NAME}" \
HTTP 422: Validation Failed (https://api.github.com/repos/groonga/docker/releases)
Release.tag_name already exists
Error: Process completed with exit code 1.
```
https://github.com/groonga/docker/actions/runs/14924269738/job/41925474106

## Solution

After publishing each image, we will create a GitHub Release page listing all image tags and digests.