### PR TITLE
debian: use trixie

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \


### PR DESCRIPTION
We have not been already provided Groonga package for Debian bookworm since 16.0.8. 
Because Debian bookworm has already reached EOL.